### PR TITLE
feat(api): Add v1 versioning structure

### DIFF
--- a/setup/api_urls.py
+++ b/setup/api_urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+urlpatterns = [
+    # Authentication endpoints
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+
+    # App-specific API URLs will be added here
+    # path('products/', include('produtos.api_urls')),
+]

--- a/setup/urls.py
+++ b/setup/urls.py
@@ -2,11 +2,6 @@ from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView
 
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-)
-
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('usuarios/', include('usuarios.urls')),
@@ -14,6 +9,5 @@ urlpatterns = [
     path('vendas/', include('vendas.urls', namespace='vendas')),
     path('produtos/', include('produtos.urls', namespace='produtos')),
 
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/v1/', include('setup.api_urls')),
 ]


### PR DESCRIPTION
Refactors the URL configuration to group all API endpoints under the versioned prefix /api/v1/.
- Creates a central api_urls.py file for better organization.
- Ensures the API can evolve in the future (v2, v3) without breaking existing clients. 
Closes #9