### PR TITLE
feat(api): Configure global LimitOffset pagination

### DIFF
--- a/setup/base.py
+++ b/setup/base.py
@@ -104,4 +104,6 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
 }


### PR DESCRIPTION
Sets up LimitOffsetPagination as the default pagination style for the entire API in the DRF settings.

- Sets a default PAGE_SIZE of 100 to prevent large, unpaginated responses.
- This ensures better performance and a consistent response structure for all list endpoints.

Closes #11