### PR TITLE
feat(products): Create serializers for the Product model

### DIFF
--- a/produtos/api_serializers.py
+++ b/produtos/api_serializers.py
@@ -1,0 +1,45 @@
+from rest_framework import serializers
+from produtos.models import Produto
+
+class ProductSerializer(serializers.ModelSerializer):
+    """
+    Serializer to represent the Product model.
+    """
+
+    category_display = serializers.CharField(source='get_categoria_display', read_only=True)
+
+    unit_of_measure_display = serializers.CharField(source='get_unidade_medida_display', read_only=True)
+
+    class Meta:
+        model = Produto
+        fields = [
+            'id',
+            'codigo',
+            'nome',
+            'descricao',
+            'preco_custo',
+            'margem_lucro',
+            'preco_venda',
+            'quantidade',
+            'unidade_medida',
+            'unit_of_measure_display', 
+            'categoria',
+            'category_display',
+            'fornecedor',
+            'ativo',
+            'imagem',
+            'endereco_estoque',
+            'data_cadastro',
+            'horario_atualizacao',
+            'data_validade',
+            'quantidade_minima',
+
+        ]
+
+        read_only_fields = [
+            'id',
+            'codigo',
+            'preco_venda',
+            'data_cadastro',
+            'horario_atualizacao',
+        ]


### PR DESCRIPTION
Implements the ProductSerializer using DRF's ModelSerializer to handle the conversion of Product instances to and from JSON.

- Defines the fields to be exposed through the API.
- Sets read-only fields like `id`, `code`, and the auto-calculated `sale_price` to prevent them from being written to via the API.
- Adds display fields for choices like `category` and `unit_of_measure` for a more user-friendly API response.

This is the first step in building the products API module.

Closes #13