### PR TITLE
feat(products): Configure routes and filters for Product API

### DIFF
--- a/produtos/api_views.py
+++ b/produtos/api_views.py
@@ -11,6 +11,9 @@ class ProductViewSet(viewsets.ModelViewSet):
     serializer_class = ProductSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    filterset_fields = ['category', 'supplier', 'is_active']
+    search_fields = ['name', 'description', 'code']
+
     def perform_create(self, serializer):
         last_product = Product.objects.order_by('-code').first()
         if last_product and last_product.code.isdigit():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ djangorestframework
 djangorestframework-simplejwt
 django-environ
 Pillow
-psycopg2-binary 
+django-filter

--- a/setup/api_urls.py
+++ b/setup/api_urls.py
@@ -11,6 +11,5 @@ urlpatterns = [
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
     # App-specific API URLs will be added here
-    # path('products/', include('produtos.api_urls')),
     path('', include('produtos.api_urls')),
 ]

--- a/setup/base.py
+++ b/setup/base.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'django_filters',
 
     # Apps
     'core.apps.CoreConfig',
@@ -109,4 +110,9 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
 
     'EXCEPTION_HANDLER': 'core.exception_handler.custom_exception_handler',
+
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter',
+    ],
 }


### PR DESCRIPTION
Implements routing for the ProductViewSet and adds powerful filtering capabilities.

- Registers the ProductViewSet with a DRF router, automatically creating all necessary CRUD URLs under `/api/v1/products/`.
- Installs and configures `django-filter` for exact-match filtering on fields like `category` and `is_active`.
- Configures DRF's built-in `SearchFilter` for partial-text search on `name`, `description`, and `code`.
- This enables clients to efficiently query and find specific products.

Closes #15