### PR TITLE
feat(users): Configure routes and filters for Users API

### DIFF
--- a/setup/api_urls.py
+++ b/setup/api_urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     # App-specific API URLs will be added here
     path('', include('produtos.api_urls')),
     path('', include('vendas.api_urls')), 
+    path('', include('usuarios.api_urls')),
 ]

--- a/usuarios/api_urls.py
+++ b/usuarios/api_urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import DefaultRouter
+from .api_views import UserViewSet
+
+router = DefaultRouter()
+router.register(r'users', UserViewSet, basename='user')
+
+urlpatterns = router.urls

--- a/usuarios/api_views.py
+++ b/usuarios/api_views.py
@@ -11,6 +11,10 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = CustomUser.objects.all().order_by('-date_joined')
     permission_classes = [IsAdminOrIsSelf]
 
+    filterset_fields = ['user_type', 'is_active']
+
+    search_fields = ['username', 'email', 'first_name', 'last_name']
+
     def get_serializer_class(self):
         """
         Return the appropriate serializer class based on the request action.


### PR DESCRIPTION
Implements filtering capabilities for the UserViewSet and formalizes its routing.

- Adds `filterset_fields` to `UserViewSet` to allow exact-match filtering by `user_type` and `is_active`.
- Adds `search_fields` for partial-text search on `username`, `email`, and name fields.
- The endpoint remains protected by the `IsAdminOrIsSelf` permission, ensuring that only admins can use the list and filter functionalities.

Closes #27