### PR TITLE
feat(docs): Configure drf-spectacular for OpenAPI/Swagger docs

### DIFF
--- a/produtos/api_views.py
+++ b/produtos/api_views.py
@@ -5,8 +5,9 @@ from produtos.models import Product
 from .api_serializers import ProductSerializer, StockMovementSerializer
 from .models import StockMovement
 from usuarios.api_permissions import IsAdminOrStocker 
+from drf_spectacular.utils import extend_schema
 
-
+@extend_schema(tags=['Produtos'])
 class ProductViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows products to be viewed or edited.
@@ -33,7 +34,7 @@ class ProductViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         serializer.save(updated_by=self.request.user)
 
-
+@extend_schema(tags=['Produtos'])
 class StockMovementViewSet(viewsets.ReadOnlyModelViewSet):
     """
     A read-only API endpoint for viewing stock movements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-environ
 Pillow
 django-filter
 structlog
+drf-spectacular

--- a/setup/api_urls.py
+++ b/setup/api_urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('token/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
-    # App-specific API URLs will be added here
+    # App-specific API URLs
     path('', include('produtos.api_urls')),
     path('', include('vendas.api_urls')), 
     path('', include('usuarios.api_urls')),

--- a/setup/base.py
+++ b/setup/base.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'django_filters',
+    'drf_spectacular',
 
     # Apps
     'core.apps.CoreConfig',
@@ -105,6 +106,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = 'usuarios.CustomUser'
 
 REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
@@ -170,3 +172,10 @@ structlog.configure(
     wrapper_class=structlog.stdlib.BoundLogger,
     cache_logger_on_first_use=True,
 )
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Museu Magma API',
+    'DESCRIPTION': 'API para o sistema de gestão do Museu Magma, incluindo controle de produtos, vendas e usuários.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}

--- a/setup/urls.py
+++ b/setup/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -10,4 +11,8 @@ urlpatterns = [
     path('produtos/', include('produtos.urls', namespace='produtos')),
 
     path('api/v1/', include('setup.api_urls')),
+
+    path('api/v1/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/v1/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/v1/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/setup/views.py
+++ b/setup/views.py
@@ -1,7 +1,9 @@
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
+from drf_spectacular.utils import extend_schema
 
+@extend_schema(tags=['Monitoramento'])
 class HealthCheckView(APIView):
     """
     A simple view to check if the API is operational.

--- a/usuarios/api_views.py
+++ b/usuarios/api_views.py
@@ -2,8 +2,10 @@ from rest_framework import viewsets, permissions
 from .models import CustomUser
 from .api_serializers import UserSerializer, UserCreateSerializer
 from .api_permissions import IsAdminOrIsSelf
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView 
+from drf_spectacular.utils import extend_schema
 
+@extend_schema(tags=['Usuários'])
 class UserViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows users to be viewed or edited.
@@ -24,8 +26,16 @@ class UserViewSet(viewsets.ModelViewSet):
             return UserCreateSerializer
         return UserSerializer
 
+@extend_schema(tags=['Autenticação'])
 class CustomTokenObtainPairView(TokenObtainPairView):
     """
     Custom view for the token endpoint to apply a specific throttle scope.
     """
     throttle_scope = 'login'
+
+@extend_schema(tags=['Autenticação']) # 4. Adicione o decorador aqui também
+class CustomTokenRefreshView(TokenRefreshView):
+    """
+    Custom view for the token refresh endpoint.
+    """
+    pass

--- a/vendas/api_views.py
+++ b/vendas/api_views.py
@@ -3,7 +3,9 @@ from rest_framework import permissions, viewsets
 from .api_serializers import CustomerSerializer, SaleItemReadSerializer, SaleSerializer
 from .models import Customer, Sale, SaleItem
 from usuarios.api_permissions import IsAdminOrSaleOwner
+from drf_spectacular.utils import extend_schema
 
+@extend_schema(tags=['Clientes'])
 class CustomerViewSet(viewsets.ModelViewSet):
     queryset = Customer.objects.all()
     serializer_class = CustomerSerializer
@@ -12,7 +14,7 @@ class CustomerViewSet(viewsets.ModelViewSet):
     filterset_fields = ['customer_type']
     search_fields = ['name', 'document', 'email']
 
-
+@extend_schema(tags=['Vendas'])
 class SaleViewSet(viewsets.ModelViewSet):
     queryset = Sale.objects.all()
     serializer_class = SaleSerializer
@@ -40,7 +42,7 @@ class SaleViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         serializer.save(updated_by=self.request.user)
 
-
+@extend_schema(tags=['Vendas'])
 class SaleItemViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = SaleItem.objects.all()
     serializer_class = SaleItemReadSerializer


### PR DESCRIPTION
Implements automated API documentation generation using `drf-spectacular`.

- Adds `drf-spectacular` to the project dependencies and configuration.
- Configures DRF to use `AutoSchema` for automatic introspection of ViewSets, Serializers, and models.
- Exposes three new endpoints:
    - `api/v1/schema/` for the OpenAPI schema in JSON format.
    - `api/v1/docs/` for the Swagger UI.
    - `api/v1/docs/` for the ReDoc UI.
- This provides a professional, self-documenting interface for the API, crucial for frontend integration and external developers.

Closes #34